### PR TITLE
CircleCI config, quay.io Docker builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 *.test
+vendor/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Go Coordinate Daemon
 ====================
 
+[![CircleCI](https://circleci.com/gh/diffeo/go-coordinate.svg?style=svg)](https://circleci.com/gh/diffeo/go-coordinate)
+[![Docker Repository on Quay](https://quay.io/repository/diffeo/coordinated/status "Docker Repository on Quay")](https://quay.io/repository/diffeo/coordinated)
+
 This package provides a reimplementation of the Diffeo Coordinate
 (https://github.com/diffeo/coordinate) daemon.  It is fully compatible
 with existing Python Coordinate code, and provides a REST interface

--- a/circle.yml
+++ b/circle.yml
@@ -67,5 +67,6 @@ test:
     - go vet -x $(glide novendor)
 
   override:
-    # run the tests with race detection
-    - go test -v -race $(glide novendor)
+    # run the tests
+    # TODO: add -race flag once race conditions have been eliminated.
+    - go test -v $(glide novendor)

--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,8 @@ general:
   build_dir: ../.go_workspace/src/$IMPORT_PATH
 
 machine:
+  services:
+    - docker
   environment:
     DEPS: $HOME/deps
     GOPATH: $HOME/.go_workspace
@@ -60,6 +62,19 @@ dependencies:
     # build the app, installing for faster subsequent test execution
     - go install -v $(glide novendor)
 
+    # make `git describe HEAD` work as expected
+    - git fetch --unshallow
+
+    # create directory for the build to occur within
+    - mkdir -p build
+
+    # Run Docker setup script, preparing the build an image
+    - ../setup.sh:
+        pwd: build
+    # Build the docker image
+    - docker build -t quay.io/diffeo/coordinated:$(cat container-version) .:
+        pwd: build
+
 test:
   pre:
     # linting and vetting tools
@@ -70,3 +85,15 @@ test:
     # run the tests
     # TODO: add -race flag once race conditions have been eliminated.
     - go test -v $(glide novendor)
+
+deployment:
+  dev:
+    branch: master
+    owner: diffeo
+    commands:
+      # Login to our quay.io repository
+      - docker login -u "$DOCKER_USER" -p "$DOCKER_PASS" -e bot@diffeo.com quay.io:
+          pwd: build
+      # push image to our repository
+      - docker push quay.io/diffeo/coordinated:$(cat container-version):
+          pwd: build

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,71 @@
+# Circle CI configuration
+
+general:
+  # Build within the GOPATH in order to use standard Go tooling.
+  # The location is relative to the default location.
+  build_dir: ../.go_workspace/src/$IMPORT_PATH
+
+machine:
+  environment:
+    DEPS: $HOME/deps
+    GOPATH: $HOME/.go_workspace
+    IMPORT_PATH: github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+
+    # dependency version definitions
+    GLIDEV: v0.12.2
+
+checkout:
+  post:
+    # Prepare the GOPATH and copy the current version of this repo into it
+    - |
+      set -euo pipefail
+
+      mkdir -p "$GOPATH/src/$(dirname $IMPORT_PATH)"
+      rm -rf $GOPATH/src/$IMPORT_PATH
+      cp -r $HOME/$CIRCLE_PROJECT_REPONAME $GOPATH/src/$IMPORT_PATH
+
+dependencies:
+  cache_directories:
+    # env variables aren't supported here
+    - ~/deps
+    - ~/.glide
+  pre:
+    - |
+      set -euo pipefail
+
+      mkdir -p $DEPS
+
+      # Glide dependency manager (wget is used to follow github redirects)
+      if [ ! -d "$DEPS/glide-$GLIDEV" ]; then
+        wget -O "$DEPS/glide-$GLIDEV-linux-amd64.zip" "https://github.com/Masterminds/glide/releases/download/$GLIDEV/glide-$GLIDEV-linux-amd64.zip"
+        unzip -o -d "$DEPS/glide-$GLIDEV" "$DEPS/glide-$GLIDEV-linux-amd64.zip"
+        cp "$DEPS/glide-$GLIDEV/linux-amd64/glide" $HOME/bin/glide;
+      else
+        cp "$DEPS/glide-$GLIDEV/linux-amd64/glide" $HOME/bin/glide;
+        echo "glide version $GLIDEV already installed"
+      fi
+
+      go get github.com/golang/lint/golint
+
+      ls -l $DEPS $HOME/bin
+
+      # print out versions
+      go version
+      glide --version
+
+  override:
+    # get dependencies
+    - glide install
+
+    # build the app, installing for faster subsequent test execution
+    - go install -v $(glide novendor)
+
+test:
+  pre:
+    # linting and vetting tools
+    - golint -min_confidence=0.8 $(glide novendor)
+    - go vet -x $(glide novendor)
+
+  override:
+    # run the tests with race detection
+    - go test -v -race $(glide novendor)

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,56 @@
+hash: 620d232aa42d50399a155bab76d14a0d2c11422b5a6c34c3eadac582867906ff
+updated: 2017-01-17T13:33:12.633153811-05:00
+imports:
+- name: github.com/benbjohnson/clock
+  version: 7dc76406b6d3c05b5f71a86293cbcf3c4ea03b19
+- name: github.com/codegangsta/cli
+  version: f1be59ff3d239f0942b201619030d302bce912cc
+- name: github.com/davecgh/go-spew
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  subpackages:
+  - spew
+- name: github.com/gorilla/context
+  version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
+- name: github.com/gorilla/mux
+  version: 757bef944d0f21880861c2dd9c871ca543023cba
+- name: github.com/jtacoma/uritemplates
+  version: 307ae868f90f4ee1b73ebe4596e0394237dacce8
+- name: github.com/lib/pq
+  version: 8df6253d1317616f36b0c3740eb30c239a7372cb
+  subpackages:
+  - oid
+- name: github.com/mitchellh/mapstructure
+  version: bfdb1a85537d60bc7e954e600c250219ea497417
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/rubenv/sql-migrate
+  version: 1ed79968dfca5de79adb13c84523caaa4fc865a9
+  subpackages:
+  - sqlparse
+- name: github.com/satori/go.uuid
+  version: b061729afc07e77a8aa4fad0a2fd840958f1942a
+- name: github.com/Sirupsen/logrus
+  version: d26492970760ca5d33129d2d799e34be5c4782eb
+- name: github.com/stretchr/testify
+  version: 2402e8e7a02fc811447d11f881aa9746cdc57983
+  subpackages:
+  - assert
+- name: github.com/ugorji/go
+  version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
+  subpackages:
+  - codec
+- name: golang.org/x/net
+  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
+  subpackages:
+  - context
+- name: golang.org/x/sys
+  version: d75a52659825e75fff6158388dddc6a5b04f9ba5
+  subpackages:
+  - unix
+- name: gopkg.in/gorp.v1
+  version: c87af80f3cc5036b55b83d77171e156791085e2e
+- name: gopkg.in/yaml.v2
+  version: a5b47d31c556af34a302ce5d659e6fea44d90de0
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,21 @@
+package: github.com/diffeo/go-coordinate
+import:
+- package: github.com/Sirupsen/logrus
+- package: github.com/benbjohnson/clock
+- package: github.com/codegangsta/cli
+- package: github.com/gorilla/mux
+- package: github.com/jtacoma/uritemplates
+- package: github.com/lib/pq
+- package: github.com/mitchellh/mapstructure
+- package: github.com/rubenv/sql-migrate
+- package: github.com/satori/go.uuid
+- package: github.com/stretchr/testify
+  subpackages:
+  - assert
+- package: github.com/ugorji/go
+  subpackages:
+  - codec
+- package: golang.org/x/net
+  subpackages:
+  - context
+- package: gopkg.in/yaml.v2

--- a/setup.sh
+++ b/setup.sh
@@ -21,7 +21,7 @@ GO_SUBMODULE="cmd/coordinated"
 set -e
 
 # Directory containing this script
-D=$(cd $(dirname "$0") && pwd -P)
+D=$(cd "$(dirname "$0")" && pwd -P)
 
 # Output directory
 O=$(pwd -P)


### PR DESCRIPTION
This PR adds configuration to build this repo in CircleCI and push built images to quay.io.

Currently, a push to quay.io happens on every build of master. If this isn't desirable, we can move it to occur only on release tags.

⚠️ ⚠️ ⚠️ I had to turn off the `-race` flag of `go test` to get this build to work. @dmaze In future work we should eliminate race conditions.