### PR TITLE
Use Go 1.7+ standard context in go-coordinate

### DIFF
--- a/cmd/demoworker/demoworker.go
+++ b/cmd/demoworker/demoworker.go
@@ -8,14 +8,15 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
+	"strings"
+
 	"github.com/diffeo/go-coordinate/backend"
 	"github.com/diffeo/go-coordinate/coordinate"
 	"github.com/diffeo/go-coordinate/worker"
 	"github.com/mitchellh/mapstructure"
-	"golang.org/x/net/context"
-	"strings"
 )
 
 func main() {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -6,15 +6,16 @@
 package worker
 
 import (
+	"context"
 	"fmt"
-	"github.com/benbjohnson/clock"
-	"github.com/diffeo/go-coordinate/coordinate"
-	"github.com/satori/go.uuid"
-	"golang.org/x/net/context"
 	"net"
 	"os"
 	"runtime"
 	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/diffeo/go-coordinate/coordinate"
+	"github.com/satori/go.uuid"
 )
 
 // Worker is foo.

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -4,13 +4,14 @@
 package worker
 
 import (
+	"context"
+	"testing"
+	"time"
+
 	"github.com/benbjohnson/clock"
 	"github.com/diffeo/go-coordinate/coordinate"
 	"github.com/diffeo/go-coordinate/memory"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
-	"testing"
-	"time"
 )
 
 type Suite struct {


### PR DESCRIPTION
This PR updates the imports in go-coordinate so code using contexts will import from the standard `context` package introduced in Go 1.7, rather than golang.org/x/net/context. The only concern is the possibility of a net/context rabbit hole, but the only non-Appengine packages using net/context that I found in ctrl-shift-F are in diffeo-go/worker, so I don't think we'll have much of a rabbit hole.