### PR TITLE
Publish "coordinate summary" style metrics to Prometheus

### DIFF
--- a/cache/coordinate.go
+++ b/cache/coordinate.go
@@ -97,3 +97,7 @@ func (cache *cache) invalidate(name string) {
 func (cache *cache) Namespaces() (map[string]coordinate.Namespace, error) {
 	return cache.backend.Namespaces()
 }
+
+func (cache *cache) Summarize() (coordinate.Summary, error) {
+	return cache.backend.Summarize()
+}

--- a/cache/namespace.go
+++ b/cache/namespace.go
@@ -186,3 +186,12 @@ func (ns *namespace) Workers() (workers map[string]coordinate.Worker, err error)
 	}
 	return
 }
+
+func (ns *namespace) Summarize() (summary coordinate.Summary, err error) {
+	err = ns.withNamespace(func(namespace coordinate.Namespace) error {
+		var err error
+		summary, err = namespace.Summarize()
+		return err
+	})
+	return
+}

--- a/cache/work_spec.go
+++ b/cache/work_spec.go
@@ -167,3 +167,12 @@ func (spec *workSpec) DeleteWorkUnits(q coordinate.WorkUnitQuery) (count int, er
 	})
 	return
 }
+
+func (spec *workSpec) Summarize() (summary coordinate.Summary, err error) {
+	err = spec.withWorkSpec(func(workSpec coordinate.WorkSpec) error {
+		var err error
+		summary, err = workSpec.Summarize()
+		return err
+	})
+	return
+}

--- a/cmd/coordinated/main.go
+++ b/cmd/coordinated/main.go
@@ -64,7 +64,13 @@ func main() {
 	}
 
 	go ServeCBORRPC(coordinate, gConfig, "tcp", *cborRPCBind, reqLogger)
-	go ServeHTTP(coordinate, *httpBind)
+	http := HTTP{
+		coord: coordinate,
+		laddr: *httpBind,
+	}
+	go http.Serve()
+	go observe(coordinate)
+
 	select {}
 }
 

--- a/cmd/coordinated/metrics.go
+++ b/cmd/coordinated/metrics.go
@@ -1,0 +1,41 @@
+// Copyright 2015-2017 Diffeo, Inc.
+// This software is released under an MIT/X11 open source license.
+
+package main
+
+import (
+	"github.com/diffeo/go-coordinate/coordinate"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var coordinateSummary = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Namespace: "diffeo",
+		Subsystem: "coordinate",
+		Name:      "coordinate_summary",
+		Help:      "Summary of coordinate work specs",
+	},
+	[]string{
+		"namespace",
+		"work_spec",
+		"status",
+	},
+)
+
+func init() {
+	prometheus.MustRegister(coordinateSummary)
+}
+
+func observe(coord coordinate.Coordinate) {
+	for {
+		summary, _ := coord.Summarize()
+		for _, record := range summary {
+			statusBytes, _ := record.Status.MarshalJSON()
+			coordinateSummary.With(prometheus.Labels{
+				"namespace": record.Namespace,
+				"work_spec": record.WorkSpec,
+				"status":    string(statusBytes),
+			}).Set(float64(record.Count))
+		}
+	}
+}

--- a/cmd/coordinated/metrics.go
+++ b/cmd/coordinated/metrics.go
@@ -4,38 +4,75 @@
 package main
 
 import (
+	"context"
+	"math"
+	"time"
+
 	"github.com/diffeo/go-coordinate/coordinate"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
 )
 
-var coordinateSummary = prometheus.NewGaugeVec(
-	prometheus.GaugeOpts{
-		Namespace: "diffeo",
-		Subsystem: "coordinate",
-		Name:      "coordinate_summary",
-		Help:      "Summary of coordinate work specs",
-	},
-	[]string{
-		"namespace",
-		"work_spec",
-		"status",
-	},
+var (
+	workUnitsNumber = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "coordinate",
+			Name:      "summary_seconds",
+			Help:      "Seconds required to gather coordinate summary",
+			Buckets:   prometheus.ExponentialBuckets(math.Pow(2, -5), 2, 12),
+		})
+
+	summarySeconds = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "coordinate",
+			Name:      "work_units",
+			Help:      "Number of coordinate work specs",
+		},
+		[]string{
+			"namespace",
+			"work_spec",
+			"status",
+		})
 )
 
 func init() {
-	prometheus.MustRegister(coordinateSummary)
+	prometheus.MustRegister(summarySeconds)
+	prometheus.MustRegister(workUnitsNumber)
 }
 
-func observe(coord coordinate.Coordinate) {
+// Observe repeatedly calls Summarize() on coordinate in an infinite loop, and
+// observes each SummaryRecord's fields on a prometheus GaugeVec, and the
+// resultant time duration on a prometheus Histogram.
+func Observe(
+	ctx context.Context,
+	coord coordinate.Coordinate,
+	period time.Duration,
+	log *logrus.Logger,
+) {
 	for {
-		summary, _ := coord.Summarize()
-		for _, record := range summary {
-			statusBytes, _ := record.Status.MarshalJSON()
-			coordinateSummary.With(prometheus.Labels{
-				"namespace": record.Namespace,
-				"work_spec": record.WorkSpec,
-				"status":    string(statusBytes),
-			}).Set(float64(record.Count))
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(period):
+			t0 := time.Now()
+			summary, err := coord.Summarize()
+			if err != nil {
+				log.Error(err)
+				break
+			}
+			workUnitsNumber.Observe(time.Since(t0).Seconds())
+			for _, record := range summary {
+				status, err := record.Status.MarshalText()
+				if err != nil {
+					log.Error(err)
+					break
+				}
+				summarySeconds.With(prometheus.Labels{
+					"namespace": record.Namespace,
+					"work_spec": record.WorkSpec,
+					"status":    status,
+				}).Set(float64(record.Count))
+			}
 		}
 	}
 }

--- a/coordinate/coordinate.go
+++ b/coordinate/coordinate.go
@@ -19,6 +19,8 @@ import "time"
 // Implementations of this interface provide a specific database backend,
 // RPC system, or other way to interact with Coordinate.
 type Coordinate interface {
+	Summarizable
+
 	// Namespace retrieves a Namespace object for some name.  If
 	// no namespace already exists with that name, creates one.
 	// Coordinate implementations such as the Python one that do
@@ -34,6 +36,8 @@ type Coordinate interface {
 // namespace is tied to a single Coordinate backend.  Most
 // applications will only need to interact with a single namespace.
 type Namespace interface {
+	Summarizable
+
 	// Name returns the name of this namespace.  This may be an
 	// empty string.
 	Name() string
@@ -287,6 +291,8 @@ type WorkUnitQuery struct {
 // (string) and meanings.  A work spec also has any number of WorkUnit
 // associated with it.
 type WorkSpec interface {
+	Summarizable
+
 	// Name returns the name of this work spec.
 	Name() string
 

--- a/coordinate/marshal.go
+++ b/coordinate/marshal.go
@@ -48,6 +48,15 @@ func (status *WorkUnitStatus) UnmarshalJSON(json []byte) error {
 	return nil
 }
 
+// MarshalText returns a string representing a work unit status.
+func (status WorkUnitStatus) MarshalText() (string, error) {
+	b, err := status.MarshalJSON()
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
 // MarshalJSON represents an attempt status as a JSON string.
 func (status AttemptStatus) MarshalJSON() ([]byte, error) {
 	switch status {

--- a/coordinate/stats.go
+++ b/coordinate/stats.go
@@ -1,0 +1,52 @@
+// Statistics for Coordinate objects.
+//
+// Copyright 2017 Diffeo, Inc.
+// This software is released under an MIT/X11 open source license.
+
+package coordinate
+
+import (
+	"sort"
+)
+
+// SummaryRecord is a single piece of summary data, recording how
+// many work units were in some status in some work spec.
+type SummaryRecord struct {
+	Namespace string
+	WorkSpec  string
+	Status    WorkUnitStatus
+	Count     int
+}
+
+// Summary is a summary of work unit statuses for some part of
+// the Coordinate system.  The records are in no particular order.
+// The records should not contain records with zero count.
+type Summary []SummaryRecord
+
+// Sort sorts the records of a summary in place.
+func (s Summary) Sort() {
+	less := func(i, j int) bool {
+		if s[i].Namespace < s[j].Namespace {
+			return true
+		}
+		if s[i].Namespace > s[j].Namespace {
+			return false
+		}
+		if s[i].WorkSpec < s[j].WorkSpec {
+			return true
+		}
+		if s[i].WorkSpec > s[j].WorkSpec {
+			return false
+		}
+		return s[i].Status < s[j].Status
+	}
+	sort.Slice(s, less)
+}
+
+// Summarizable describes Coordinate objects that can be summarized.
+// The summary is not required to have exact counts of work units;
+// counts may be rounded, delayed, not account for recently-expired
+// work units, and so on.
+type Summarizable interface {
+	Summarize() (Summary, error)
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,20 @@
-hash: 9bf66dbc8240f696b14f23a4496e4def68d580d0b5304e024aac60bc84d00ff1
-updated: 2017-05-04T09:32:35.077646325-04:00
+hash: 93f555948f80ce6817f2d3a8e280998930a3f0a7690032c94f2f1e448825f187
+updated: 2017-05-26T12:57:00.647338187-04:00
 imports:
 - name: github.com/benbjohnson/clock
   version: 7dc76406b6d3c05b5f71a86293cbcf3c4ea03b19
+- name: github.com/beorn7/perks
+  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  subpackages:
+  - quantile
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
+- name: github.com/golang/protobuf
+  version: 2bba0603135d7d7f5cb73b2125beeda19c09f4ef
+  subpackages:
+  - proto
 - name: github.com/gorilla/context
   version: 1ea25387ff6f684839d82767c1733ff4d4d15d0a
 - name: github.com/gorilla/mux
@@ -17,6 +25,10 @@ imports:
   version: 472a0745531a17dbac346e828b4c60e73ddff30c
   subpackages:
   - oid
+- name: github.com/matttproud/golang_protobuf_extensions
+  version: 3247c84500bff8d9fb6d579d800f20b3e091582c
+  subpackages:
+  - pbutil
 - name: github.com/mitchellh/mapstructure
   version: 53818660ed4955e899c0bcafa97299a388bd7c8e
 - name: github.com/pmezard/go-difflib
@@ -54,6 +66,8 @@ imports:
   version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
+  - require
+  - suite
 - name: github.com/ugorji/go
   version: 708a42d246822952f38190a8d8c4e6b16a0e600c
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -23,6 +23,25 @@ imports:
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
+- name: github.com/prometheus/client_golang
+  version: c5b7fccd204277076155f10851dad72b76a49317
+  subpackages:
+  - prometheus
+  - prometheus/promhttp
+- name: github.com/prometheus/client_model
+  version: 6f3806018612930941127f2a7c6c453ba2c527d2
+  subpackages:
+  - go
+- name: github.com/prometheus/common
+  version: 49fee292b27bfff7f354ee0f64e1bc4850462edf
+  subpackages:
+  - expfmt
+  - internal/bitbucket.org/ww/goautoneg
+  - model
+- name: github.com/prometheus/procfs
+  version: a1dba9ce8baed984a2495b658c82687f8157b98f
+  subpackages:
+  - xfs
 - name: github.com/rubenv/sql-migrate
   version: a3e2963537993d229b6e257d10bd8bc640b06ce3
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -17,3 +17,8 @@ import:
   - codec
 - package: github.com/urfave/cli
 - package: gopkg.in/yaml.v2
+- package: github.com/prometheus/client_golang
+  version: ~0.8.0
+  subpackages:
+  - prometheus
+  - prometheus/promhttp

--- a/memory/coordinate.go
+++ b/memory/coordinate.go
@@ -92,6 +92,17 @@ func (c *memCoordinate) Namespaces() (map[string]coordinate.Namespace, error) {
 	return result, nil
 }
 
+func (c *memCoordinate) Summarize() (coordinate.Summary, error) {
+	globalLock(c)
+	defer globalUnlock(c)
+
+	var result coordinate.Summary
+	for _, ns := range c.namespaces {
+		result = append(result, ns.summarize()...)
+	}
+	return result, nil
+}
+
 func (c *memCoordinate) Coordinate() *memCoordinate {
 	return c
 }

--- a/memory/namespace.go
+++ b/memory/namespace.go
@@ -143,6 +143,24 @@ func (ns *namespace) Workers() (workers map[string]coordinate.Worker, err error)
 	return
 }
 
+// coordinate.Summarizable interface:
+
+func (ns *namespace) Summarize() (result coordinate.Summary, err error) {
+	err = ns.do(func() error {
+		result = ns.summarize()
+		return nil
+	})
+	return
+}
+
+func (ns *namespace) summarize() coordinate.Summary {
+	var result coordinate.Summary
+	for _, spec := range ns.workSpecs {
+		result = append(result, spec.summarize()...)
+	}
+	return result
+}
+
 // memory.coordinable interface:
 
 func (ns *namespace) Coordinate() *memCoordinate {

--- a/postgres/constants.go
+++ b/postgres/constants.go
@@ -69,14 +69,15 @@ const (
 	workUnitNotBefore           = workUnitTable + ".not_before"
 
 	// WHERE clause fragments:
-	workUnitHasNoAttempt = workUnitAttempt + " IS NULL"
-	workUnitInThisSpec   = workUnitSpec + "=" + workSpecID
-	attemptIsActive      = attemptActive + "=TRUE"
-	attemptIsPending     = attemptStatus + "='pending'"
-	attemptThisWorkUnit  = attemptWorkUnitID + "=" + workUnitID
-	attemptThisWorker    = attemptWorkerID + "=" + workerID
-	attemptIsTheActive   = attemptID + "=" + workUnitAttempt
-	attemptInThisSpec    = attemptWorkSpecID + "=" + workSpecID
+	workSpecInThisNamespace = workSpecNamespace + "=" + namespaceID
+	workUnitHasNoAttempt    = workUnitAttempt + " IS NULL"
+	workUnitInThisSpec      = workUnitSpec + "=" + workSpecID
+	attemptIsActive         = attemptActive + "=TRUE"
+	attemptIsPending        = attemptStatus + "='pending'"
+	attemptThisWorkUnit     = attemptWorkUnitID + "=" + workUnitID
+	attemptThisWorker       = attemptWorkerID + "=" + workerID
+	attemptIsTheActive      = attemptID + "=" + workUnitAttempt
+	attemptInThisSpec       = attemptWorkSpecID + "=" + workSpecID
 
 	// This join selects all work units and attempts, including
 	// work units with no active attempt
@@ -85,6 +86,10 @@ const (
 )
 
 // More WHERE clause fragments, that depend on query params:
+
+func isNamespace(params *queryParams, id int) string {
+	return namespaceID + "=" + params.Param(id)
+}
 
 func isWorkSpec(params *queryParams, id int) string {
 	return workSpecID + "=" + params.Param(id)

--- a/postgres/stats.go
+++ b/postgres/stats.go
@@ -1,0 +1,100 @@
+// Statistics generation for everything that needs it.
+//
+// Copyright 2017 Diffeo, Inc.
+// This software is released under an MIT/X11 open source license.
+
+package postgres
+
+import (
+	"database/sql"
+
+	"github.com/diffeo/go-coordinate/coordinate"
+)
+
+// summarize computes summary statistics for things.  This runs a single
+// SQL query over namespaces, work specs, work units, and attempts;
+// it selects all active attempts everywhere, further limited by
+// whatever is passed as restrictions.
+func summarize(
+	c coordinable,
+	params queryParams,
+	restrictions []string,
+) (coordinate.Summary, error) {
+	var result coordinate.Summary
+	outputs := []string{
+		namespaceName,
+		workSpecName,
+		attemptStatus,
+		workUnitTooSoon(&params, c.Coordinate().clock.Now()) + " delayed",
+		"COUNT(*)",
+	}
+	tables := []string{
+		namespaceTable,
+		workSpecTable,
+		workUnitAttemptJoin,
+	}
+	conditions := []string{
+		workSpecInThisNamespace,
+		workUnitInThisSpec,
+	}
+	conditions = append(conditions, restrictions...)
+	query := buildSelect(outputs, tables, conditions)
+	query += (" GROUP BY " + namespaceName + ", " + workSpecName + ", " +
+		attemptStatus + ", delayed")
+	err := queryAndScan(c, query, params, func(rows *sql.Rows) error {
+		var record coordinate.SummaryRecord
+		var status sql.NullString
+		var delayed bool
+		err := rows.Scan(&record.Namespace, &record.WorkSpec, &status,
+			&delayed, &record.Count)
+		if err != nil {
+			return err
+		}
+		if !status.Valid {
+			if delayed {
+				record.Status = coordinate.DelayedUnit
+			} else {
+				record.Status = coordinate.AvailableUnit
+			}
+		} else {
+			switch status.String {
+			case "expired":
+				record.Status = coordinate.AvailableUnit
+			case "retryable":
+				record.Status = coordinate.AvailableUnit
+			case "pending":
+				record.Status = coordinate.PendingUnit
+			case "finished":
+				record.Status = coordinate.FinishedUnit
+			case "failed":
+				record.Status = coordinate.FailedUnit
+			}
+		}
+		result = append(result, record)
+		return nil
+	})
+	if err != nil {
+		return coordinate.Summary{}, err
+	}
+	return result, nil
+}
+
+func (c *pgCoordinate) Summarize() (coordinate.Summary, error) {
+	return summarize(c, nil, nil)
+}
+
+func (ns *namespace) Summarize() (coordinate.Summary, error) {
+	var params queryParams
+	restrictions := []string{
+		isNamespace(&params, ns.id),
+	}
+	return summarize(ns, params, restrictions)
+}
+
+func (spec *workSpec) Summarize() (coordinate.Summary, error) {
+	var params queryParams
+	restrictions := []string{
+		isWorkSpec(&params, spec.id),
+	}
+	return summarize(spec, params, restrictions)
+}

--- a/restclient/coordinate.go
+++ b/restclient/coordinate.go
@@ -83,3 +83,9 @@ func (c *restCoordinate) Namespaces() (map[string]coordinate.Namespace, error) {
 	}
 	return result, nil
 }
+
+func (c *restCoordinate) Summarize() (coordinate.Summary, error) {
+	var summary coordinate.Summary
+	err := c.GetFrom(c.Representation.SummaryURL, nil, &summary)
+	return summary, err
+}

--- a/restclient/namespace.go
+++ b/restclient/namespace.go
@@ -107,3 +107,9 @@ func (ns *namespace) Worker(name string) (coordinate.Worker, error) {
 func (ns *namespace) Workers() (map[string]coordinate.Worker, error) {
 	return nil, errors.New("not implemented")
 }
+
+func (ns *namespace) Summarize() (coordinate.Summary, error) {
+	var summary coordinate.Summary
+	err := ns.GetFrom(ns.Representation.SummaryURL, nil, &summary)
+	return summary, err
+}

--- a/restclient/work_spec.go
+++ b/restclient/work_spec.go
@@ -169,3 +169,9 @@ func (spec *workSpec) DeleteWorkUnits(q coordinate.WorkUnitQuery) (int, error) {
 	}
 	return 0, err
 }
+
+func (spec *workSpec) Summarize() (coordinate.Summary, error) {
+	var summary coordinate.Summary
+	err := spec.GetFrom(spec.Representation.SummaryURL, nil, &summary)
+	return summary, err
+}

--- a/restdata/restdata.go
+++ b/restdata/restdata.go
@@ -149,6 +149,11 @@ type NamedResource struct {
 type RootData struct {
 	Resource
 
+	// SummaryURL points at a summary of the statuses of all of
+	// the work units in all namespaces.  This endpoint supports
+	// HTTP GET, returning a coordinate.Summary.
+	SummaryURL string `json:"summary_url"`
+
 	// NamespacesURL points at the namespace list.  This endpoint
 	// supports HTTP GET to return a NamespaceList.  This endpoint
 	// also supports HTTP POST to submit a new Namespace,
@@ -180,6 +185,11 @@ type NamespaceList struct {
 // Namespace provides pointers to associated data about a namespace.
 type Namespace struct {
 	NamespaceShort
+
+	// SummaryURL points at a summary of the statuses of all
+	// of the work units in this namespace.  This endpoint supports
+	// HTTP GET, returning a coordinate.Summary.
+	SummaryURL string `json:"summary_url"`
 
 	// WorkSpecsURL points at the list of work specs in this
 	// namespace.  This endpoint supports HTTP GET, returning a
@@ -237,6 +247,11 @@ type WorkSpec struct {
 	// be either an object or a string; if a string, it is a
 	// base64-encoded CBOR encoding of a map.
 	Data DataDict `json:"data"`
+
+	// SummaryURL points at a summary of the statuses of all
+	// of the work units in this work spec.  This endpoint supports
+	// HTTP GET, returning a coordinate.Summary.
+	SummaryURL string `json:"summary_url"`
 
 	// WorkUnitsURL points at the list of work units in this work
 	// spec.  This endpoint supports HTTP GET, returning a

--- a/restserver/namespace.go
+++ b/restserver/namespace.go
@@ -20,6 +20,7 @@ func (api *restAPI) fillNamespace(namespace coordinate.Namespace, result *restda
 	err := api.fillNamespaceShort(namespace, &result.NamespaceShort)
 	if err == nil {
 		err = buildURLs(api.Router, "namespace", result.Name).
+			URL(&result.SummaryURL, "namespaceSummary").
 			URL(&result.WorkSpecsURL, "workSpecs").
 			Template(&result.WorkSpecURL, "workSpec", "spec").
 			URL(&result.WorkersURL, "workers").
@@ -88,6 +89,11 @@ func (api *restAPI) NamespaceDelete(ctx *context) (interface{}, error) {
 	return nil, err
 }
 
+// NamespaceSummaryGet produces a summary for a namespace.
+func (api *restAPI) NamespaceSummaryGet(ctx *context) (interface{}, error) {
+	return ctx.Namespace.Summarize()
+}
+
 // PopulateNamespace adds namespace-specific routes to a router.
 // r should be rooted at the root of the Coordinate URL tree, e.g. "/".
 func (api *restAPI) PopulateNamespace(r *mux.Router) {
@@ -102,6 +108,11 @@ func (api *restAPI) PopulateNamespace(r *mux.Router) {
 		Context:        api.Context,
 		Get:            api.NamespaceGet,
 		Delete:         api.NamespaceDelete,
+	})
+	r.Path("/namespace/{namespace}/summary").Name("namespaceSummary").Handler(&resourceHandler{
+		Representation: coordinate.Summary{},
+		Context:        api.Context,
+		Get:            api.NamespaceSummaryGet,
 	})
 	sr := r.PathPrefix("/namespace/{namespace}").Subrouter()
 	api.PopulateWorkSpec(sr)

--- a/restserver/server.go
+++ b/restserver/server.go
@@ -49,13 +49,23 @@ func (api *restAPI) PopulateRouter(r *mux.Router) {
 		Context:        api.Context,
 		Get:            api.RootDocument,
 	})
+	r.Path("/summary").Name("rootSummary").Handler(&resourceHandler{
+		Representation: coordinate.Summary{},
+		Context:        api.Context,
+		Get:            api.RootSummary,
+	})
 }
 
 func (api *restAPI) RootDocument(ctx *context) (interface{}, error) {
 	resp := restdata.RootData{}
 	err := buildURLs(api.Router).
+		URL(&resp.SummaryURL, "rootSummary").
 		URL(&resp.NamespacesURL, "namespaces").
 		Template(&resp.NamespaceURL, "namespace", "namespace").
 		Error
 	return resp, err
+}
+
+func (api *restAPI) RootSummary(ctx *context) (interface{}, error) {
+	return api.Coordinate.Summarize()
 }

--- a/restserver/work_spec.go
+++ b/restserver/work_spec.go
@@ -24,6 +24,7 @@ func (api *restAPI) fillWorkSpec(namespace coordinate.Namespace, name string, re
 		err = buildURLs(api.Router,
 			"namespace", namespace.Name(),
 			"spec", name).
+			URL(&repr.SummaryURL, "workUnitSummary").
 			URL(&repr.WorkUnitsURL, "workUnits").
 			Template(&repr.WorkUnitURL, "workUnit", "unit").
 			URL(&repr.MetaURL, "workSpecMeta").
@@ -180,6 +181,11 @@ func (api *restAPI) WorkSpecAdjust(ctx *context, in interface{}) (interface{}, e
 	return nil, err
 }
 
+// WorkSpecSummary produces a summary of the current work spec.
+func (api *restAPI) WorkSpecSummary(ctx *context) (interface{}, error) {
+	return ctx.WorkSpec.Summarize()
+}
+
 // PopulateWorkSpec adds routes to a namespace router to manipulate
 // work specs.  r should generally be rooted in a subpath like
 // /namespace/{}.
@@ -217,6 +223,11 @@ func (api *restAPI) PopulateWorkSpec(r *mux.Router) {
 		Representation: restdata.WorkUnit{},
 		Context:        api.Context,
 		Post:           api.WorkSpecAdjust,
+	})
+	r.Path("/work_spec/{spec}/summary").Name("workUnitSummary").Handler(&resourceHandler{
+		Representation: coordinate.Summary{},
+		Context:        api.Context,
+		Get:            api.WorkSpecSummary,
 	})
 	sr := r.PathPrefix("/work_spec/{spec}").Subrouter()
 	api.PopulateWorkUnit(sr)


### PR DESCRIPTION
When complete, this PR will publish the basic statistics as shown in the Python `coordinate summary` command to [Prometheus](http://prometheus.io/) for external monitoring.  Fixes #7.