### PR TITLE
Don't double-quote statuses when MarshalText().

### DIFF
--- a/cmd/coordinated/metrics.go
+++ b/cmd/coordinated/metrics.go
@@ -70,7 +70,7 @@ func Observe(
 				summarySeconds.With(prometheus.Labels{
 					"namespace": record.Namespace,
 					"work_spec": record.WorkSpec,
-					"status":    status,
+					"status":    string(status),
 				}).Set(float64(record.Count))
 			}
 		}

--- a/coordinate/marshal.go
+++ b/coordinate/marshal.go
@@ -7,89 +7,80 @@ import (
 	"fmt"
 )
 
-// MarshalJSON represents a work unit status as a JSON string.
-func (status WorkUnitStatus) MarshalJSON() ([]byte, error) {
+// MarshalText returns a string representing a work unit status.
+func (status WorkUnitStatus) MarshalText() ([]byte, error) {
 	switch status {
 	case AnyStatus:
-		return []byte("\"any\""), nil
+		return []byte("any"), nil
 	case AvailableUnit:
-		return []byte("\"available\""), nil
+		return []byte("available"), nil
 	case PendingUnit:
-		return []byte("\"pending\""), nil
+		return []byte("pending"), nil
 	case FinishedUnit:
-		return []byte("\"finished\""), nil
+		return []byte("finished"), nil
 	case FailedUnit:
-		return []byte("\"failed\""), nil
+		return []byte("failed"), nil
 	case DelayedUnit:
-		return []byte("\"delayed\""), nil
+		return []byte("delayed"), nil
 	default:
 		return nil, fmt.Errorf("invalid status (marshal, %+v)", status)
 	}
 }
 
-// UnmarshalJSON populates a work unit status from a JSON string.
-func (status *WorkUnitStatus) UnmarshalJSON(json []byte) error {
-	switch string(json) {
-	case "\"any\"":
+// UnmarshalText populates a work unit status from a string.
+func (status *WorkUnitStatus) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "any":
 		*status = AnyStatus
-	case "\"available\"":
+	case "available":
 		*status = AvailableUnit
-	case "\"pending\"":
+	case "pending":
 		*status = PendingUnit
-	case "\"finished\"":
+	case "finished":
 		*status = FinishedUnit
-	case "\"failed\"":
+	case "failed":
 		*status = FailedUnit
-	case "\"delayed\"":
+	case "delayed":
 		*status = DelayedUnit
 	default:
-		return fmt.Errorf("invalid status (unmarshal, %+v)", string(json))
+		return fmt.Errorf("invalid status (unmarshal, %+v)", string(text))
 	}
 	return nil
 }
 
-// MarshalText returns a string representing a work unit status.
-func (status WorkUnitStatus) MarshalText() (string, error) {
-	b, err := status.MarshalJSON()
-	if err != nil {
-		return "", err
-	}
-	return string(b), nil
-}
-
-// MarshalJSON represents an attempt status as a JSON string.
-func (status AttemptStatus) MarshalJSON() ([]byte, error) {
+// MarshalText returns a string representing an attempt status.
+func (status AttemptStatus) MarshalText() ([]byte, error) {
 	switch status {
 	case Pending:
-		return []byte("\"pending\""), nil
+		return []byte("pending"), nil
 	case Expired:
-		return []byte("\"expired\""), nil
+		return []byte("expired"), nil
 	case Finished:
-		return []byte("\"finished\""), nil
+		return []byte("finished"), nil
 	case Failed:
-		return []byte("\"failed\""), nil
+		return []byte("failed"), nil
 	case Retryable:
-		return []byte("\"retryable\""), nil
+		return []byte("retryable"), nil
 	default:
 		return nil, fmt.Errorf("invalid status (marshal, %+v)", status)
 	}
 }
 
-// UnmarshalJSON populates an attempt status from a JSON string.
-func (status *AttemptStatus) UnmarshalJSON(json []byte) error {
-	switch string(json) {
-	case "\"pending\"":
+// UnmarshalText populates an attempt status from a string.
+func (status *AttemptStatus) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "pending":
 		*status = Pending
-	case "\"expired\"":
+	case "expired":
 		*status = Expired
-	case "\"finished\"":
+	case "finished":
 		*status = Finished
-	case "\"failed\"":
+	case "failed":
 		*status = Failed
-	case "\"retryable\"":
+	case "retryable":
 		*status = Retryable
 	default:
-		return fmt.Errorf("invalid status (unmarshal, %+v)", string(json))
+		return fmt.Errorf("invalid status (unmarshal, %+v)", string(text))
 	}
 	return nil
 }

--- a/coordinate/marshal_test.go
+++ b/coordinate/marshal_test.go
@@ -1,0 +1,185 @@
+// Unit tests for marshal.go.
+//
+// Copyright 2017 Diffeo, Inc.
+// This software is released under an MIT/X11 open source license.
+
+package coordinate_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/diffeo/go-coordinate/coordinate"
+)
+
+type WorkUnitStatusMatrix struct {
+	Status      coordinate.WorkUnitStatus
+	JSON        string
+	EncodeError string
+	DecodeError string
+}
+
+var workUnitStatuses = []WorkUnitStatusMatrix{
+	{coordinate.AvailableUnit, "available", "", ""},
+	{coordinate.PendingUnit, "pending", "", ""},
+	{coordinate.FinishedUnit, "finished", "", ""},
+	{coordinate.FailedUnit, "failed", "", ""},
+	{coordinate.DelayedUnit, "delayed", "", ""},
+	{coordinate.WorkUnitStatus(17), "seventeen",
+		"invalid status (marshal, 17)",
+		"invalid status (unmarshal, seventeen)"},
+}
+
+func TestWorkUnitToJSON(t *testing.T) {
+	for _, w := range workUnitStatuses {
+		t.Run(w.JSON, func(tt *testing.T) {
+			actual, err := json.Marshal(w.Status)
+			if w.EncodeError == "" {
+				if assert.NoError(tt, err) {
+					assert.Equal(tt, "\""+w.JSON+"\"",
+						string(actual))
+				}
+			} else {
+				assert.EqualError(tt, err,
+					"json: error calling MarshalJSON for type coordinate.WorkUnitStatus: "+w.EncodeError)
+			}
+		})
+	}
+}
+
+func TestWorkUnitToText(t *testing.T) {
+	for _, w := range workUnitStatuses {
+		t.Run(w.JSON, func(tt *testing.T) {
+			actual, err := w.Status.MarshalText()
+			if w.EncodeError == "" {
+				if assert.NoError(tt, err) {
+					assert.Equal(tt, w.JSON,
+						string(actual))
+				}
+			} else {
+				assert.EqualError(tt, err, w.EncodeError)
+			}
+		})
+	}
+}
+
+func TestWorkUnitFromJSON(t *testing.T) {
+	for _, w := range workUnitStatuses {
+		t.Run(w.JSON, func(tt *testing.T) {
+			var actual coordinate.WorkUnitStatus
+			input := []byte("\"" + w.JSON + "\"")
+			err := json.Unmarshal(input, &actual)
+			if w.DecodeError == "" {
+				if assert.NoError(tt, err) {
+					assert.Equal(tt, actual, w.Status)
+				}
+			} else {
+				assert.EqualError(tt, err, w.DecodeError)
+			}
+		})
+	}
+}
+
+func TestWorkUnitFromText(t *testing.T) {
+	for _, w := range workUnitStatuses {
+		t.Run(w.JSON, func(tt *testing.T) {
+			var actual coordinate.WorkUnitStatus
+			input := []byte(w.JSON)
+			err := actual.UnmarshalText(input)
+			if w.DecodeError == "" {
+				if assert.NoError(tt, err) {
+					assert.Equal(tt, actual, w.Status)
+				}
+			} else {
+				assert.EqualError(tt, err, w.DecodeError)
+			}
+		})
+	}
+}
+
+type AttemptStatusMatrix struct {
+	Status      coordinate.AttemptStatus
+	JSON        string
+	EncodeError string
+	DecodeError string
+}
+
+var attemptStatuses = []AttemptStatusMatrix{
+	{coordinate.Pending, "pending", "", ""},
+	{coordinate.Finished, "finished", "", ""},
+	{coordinate.Failed, "failed", "", ""},
+	{coordinate.Expired, "expired", "", ""},
+	{coordinate.Retryable, "retryable", "", ""},
+	{coordinate.AttemptStatus(17), "seventeen",
+		"invalid status (marshal, 17)",
+		"invalid status (unmarshal, seventeen)"},
+}
+
+func TestAttemptToJSON(t *testing.T) {
+	for _, w := range attemptStatuses {
+		t.Run(w.JSON, func(tt *testing.T) {
+			actual, err := json.Marshal(w.Status)
+			if w.EncodeError == "" {
+				if assert.NoError(tt, err) {
+					assert.Equal(tt, "\""+w.JSON+"\"",
+						string(actual))
+				}
+			} else {
+				assert.EqualError(tt, err,
+					"json: error calling MarshalJSON for type coordinate.AttemptStatus: "+w.EncodeError)
+			}
+		})
+	}
+}
+
+func TestAttemptToText(t *testing.T) {
+	for _, w := range attemptStatuses {
+		t.Run(w.JSON, func(tt *testing.T) {
+			actual, err := w.Status.MarshalText()
+			if w.EncodeError == "" {
+				if assert.NoError(tt, err) {
+					assert.Equal(tt, w.JSON,
+						string(actual))
+				}
+			} else {
+				assert.EqualError(tt, err, w.EncodeError)
+			}
+		})
+	}
+}
+
+func TestAttemptFromJSON(t *testing.T) {
+	for _, w := range attemptStatuses {
+		t.Run(w.JSON, func(tt *testing.T) {
+			var actual coordinate.AttemptStatus
+			input := []byte("\"" + w.JSON + "\"")
+			err := json.Unmarshal(input, &actual)
+			if w.DecodeError == "" {
+				if assert.NoError(tt, err) {
+					assert.Equal(tt, actual, w.Status)
+				}
+			} else {
+				assert.EqualError(tt, err, w.DecodeError)
+			}
+		})
+	}
+}
+
+func TestAttemptFromText(t *testing.T) {
+	for _, w := range attemptStatuses {
+		t.Run(w.JSON, func(tt *testing.T) {
+			var actual coordinate.AttemptStatus
+			input := []byte(w.JSON)
+			err := actual.UnmarshalText(input)
+			if w.DecodeError == "" {
+				if assert.NoError(tt, err) {
+					assert.Equal(tt, actual, w.Status)
+				}
+			} else {
+				assert.EqualError(tt, err, w.DecodeError)
+			}
+		})
+	}
+}

--- a/restclient/work_spec.go
+++ b/restclient/work_spec.go
@@ -93,11 +93,9 @@ func queryToParams(q coordinate.WorkUnitQuery) map[string]interface{} {
 	if q.Statuses != nil {
 		statuses := make([]interface{}, len(q.Statuses))
 		for i, status := range q.Statuses {
-			s, err := status.MarshalJSON()
+			s, err := status.MarshalText()
 			if err == nil {
-				// s should be a byte string whose first
-				// and last bytes are ASCII double quote
-				statuses[i] = string(s)[1 : len(s)-1]
+				statuses[i] = string(s)
 			} else {
 				statuses[i] = status
 			}

--- a/restserver/context.go
+++ b/restserver/context.go
@@ -136,9 +136,7 @@ func (ctx *context) WorkUnitQuery() (q coordinate.WorkUnitQuery, err error) {
 	if len(ctx.QueryParams["status"]) > 0 {
 		q.Statuses = make([]coordinate.WorkUnitStatus, len(ctx.QueryParams["status"]))
 		for i, status := range ctx.QueryParams["status"] {
-			// this is a little hokey but it should work
-			s := "\"" + status + "\""
-			err = q.Statuses[i].UnmarshalJSON([]byte(s))
+			err = q.Statuses[i].UnmarshalText([]byte(status))
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
Make coordinate.WorkUnitStatus and AttemptStatus correctly implement
encoding.TextMarshaler and encoding.TextUnmarshaler, and don't directly
implement (encoding/json).Marshaler and .Unmarshaler.  Instead rely on
(encoding/json).Marshal falling back to text marshaling if it sees a
value is text-marshalable but not JSON-marshalable.  Add tests to this
effect.

Fixes an issue where the various status enums include JSON double-quotes
when you status.MarshalText(), which they shouldn't; in particular this
comes out as double-double-quoted values in Prometheus metrics.