### PR TITLE
postgres: improve throughput when max_attempts checking is on.

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -1,6 +1,14 @@
 Major Changes
 =============
 
+0.4.5 (TBD)
+-----------
+
+* Performance fix for the PostgreSQL backend when `max_retries` is used.
+* If `max_retries` causes some work units to get preemptively failed,
+  `RequestAttempts` will return fewer than the `max_getwork` number of
+  attempts, rather than attempting to get more work, on all backends.
+
 0.4.4 (30 May 2017)
 -------------------
 

--- a/doc/work_specs.md
+++ b/doc/work_specs.md
@@ -222,7 +222,7 @@ priority values, those with alphabetically earlier work unit names.
 for each work unit, find the number of attempts that exist.  If any
 have more than the maximum, create a new attempt, mark it as "failed",
 and remove it from further consideration.  If this process removes all
-selected work units then return to "picking work units".
+selected work units then start over.
 
 **Continuous work units:** If the work unit selection chose a work
 spec with no available work units but with the "continuous" flag set


### PR DESCRIPTION
The postgres RequestAttempts() code gets an advisory lock, limiting database
churn when there are multiple workers trying to get work for the same work
spec.  The previous code checked whether any newly-created attempts are
for work units with excessive attempts inside the transaction holding this
lock.  Change this to exit the transaction, positively acquiring the attempts,
and _then_ maybe expire them, allowing other workers to continue getting
work while we're doing this checking.

As a consequence, change the behavior of RequestAttempts() so that it will
return fewer than max_getwork attempts if some of them are expired, rather
than trying to refill the queue (with smaller database batches) trying to
get all of the attempts we could.