### PR TITLE
Avoid nil logger

### DIFF
--- a/cmd/coordinated/main.go
+++ b/cmd/coordinated/main.go
@@ -56,27 +56,16 @@ func main() {
 	}
 	coordinate = cache.New(coordinate)
 
-	var reqLogger *logrus.Logger
-	if *logRequests {
-		stdlog := logrus.StandardLogger()
-		reqLogger = &logrus.Logger{
-			Out:       stdlog.Out,
-			Formatter: stdlog.Formatter,
-			Hooks:     stdlog.Hooks,
-			Level:     logrus.DebugLevel,
-		}
+	reqLogger := logrus.StandardLogger()
+	if !*logRequests {
+		reqLogger.Out = ioutil.Discard
 	}
 
-	var metricsLogger *logrus.Logger
-	if *logMetrics {
-		stdlog := logrus.StandardLogger()
-		metricsLogger = &logrus.Logger{
-			Out:       stdlog.Out,
-			Formatter: stdlog.Formatter,
-			Hooks:     stdlog.Hooks,
-			Level:     logrus.DebugLevel,
-		}
+	metricsLogger := logrus.StandardLogger()
+	if !*logMetrics {
+		metricsLogger.Out = ioutil.Discard
 	}
+
 	period, err := time.ParseDuration(*metricPeriod)
 	if err != nil {
 		return

--- a/cmd/coordinated/main.go
+++ b/cmd/coordinated/main.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"flag"
 	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/diffeo/go-coordinate/backend"
@@ -56,14 +57,17 @@ func main() {
 	}
 	coordinate = cache.New(coordinate)
 
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(ioutil.Discard) // default unless log flags are passed
+
 	reqLogger := logrus.StandardLogger()
-	if !*logRequests {
-		reqLogger.Out = ioutil.Discard
+	if *logRequests {
+		reqLogger.Out = os.Stderr
 	}
 
 	metricsLogger := logrus.StandardLogger()
-	if !*logMetrics {
-		metricsLogger.Out = ioutil.Discard
+	if *logMetrics {
+		metricsLogger.Out = os.Stderr
 	}
 
 	period, err := time.ParseDuration(*metricPeriod)


### PR DESCRIPTION
Always define a logger, even without passed CLI flag. And set output of logger to `ioutil.Discard` whenever no logging flags are passed.