### PR TITLE
worker: fix data race

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -81,9 +81,7 @@ test:
     - go vet -x $(glide novendor)
 
   override:
-    # run the tests
-    # TODO: add -race flag once race conditions have been eliminated.
-    - go test -v $(glide novendor)
+    - go test -race -v $(glide novendor)
 
 deployment:
   dev:

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -1,6 +1,12 @@
 Major Changes
 =============
 
+0.4.8 (21 Dec 2017)
+-------------------
+
+* Fix a data race.
+  ([#16](https://github.com/diffeo/go-coordinate/pull/16))
+
 0.4.7 (29 Aug 2017)
 -------------------
 


### PR DESCRIPTION
This commit fixes a data race where the worker's cancellation map was
read and written to simultaneously from multiple goroutines.

We fix this by using a sync.Map. While I think a regular map with a mutex
would be better for type safety, this was an easier change to make.
In particular, it's not clear if there would be any performance regressions
from a mutex (or deadlocks from a misapplied mutex), so we go the safe
route and use a safe concurrent map.