### PR TITLE
Adds NumAttempts() method

### DIFF
--- a/cache/work_unit.go
+++ b/cache/work_unit.go
@@ -134,3 +134,13 @@ func (unit *workUnit) Attempts() (attempts []coordinate.Attempt, err error) {
 	})
 	return
 }
+
+func (unit *workUnit) NumAttempts() (int, error) {
+	n := 0
+	var err error
+	unit.withWorkUnit(func(workUnit coordinate.WorkUnit) (err error) {
+		n, err = workUnit.NumAttempts()
+		return err
+	})
+	return n, err
+}

--- a/coordinate/coordinate.go
+++ b/coordinate/coordinate.go
@@ -468,6 +468,10 @@ type WorkUnit interface {
 	// work unit, if any.  This includes the attempt reported by
 	// ActiveAttempt().
 	Attempts() ([]Attempt, error)
+
+	// NumAttempts returns the number of times this work unit has
+	// been attempted.
+	NumAttempts() (int, error)
 }
 
 // AttemptRequest describes parameters to Worker.RequestAttempts().

--- a/memory/work_unit.go
+++ b/memory/work_unit.go
@@ -147,6 +147,15 @@ func (unit *workUnit) ClearActiveAttempt() error {
 	})
 }
 
+func (unit *workUnit) NumAttempts() (int, error) {
+	num := 0
+	unit.do(func() error {
+		num = len(unit.attempts)
+		return nil
+	})
+	return num, nil
+}
+
 func (unit *workUnit) Attempts() (attempts []coordinate.Attempt, err error) {
 	err = unit.do(func() error {
 		attempts = make([]coordinate.Attempt, len(unit.attempts))

--- a/postgres/attempt.go
+++ b/postgres/attempt.go
@@ -409,9 +409,6 @@ func (unit *workUnit) Attempts() ([]coordinate.Attempt, error) {
 	return result, nil
 }
 
-// countAttempts is a simpler purely-internal function (it is not part
-// of the standard Coordinate API) that just finds how many attempts
-// there are for a work unit.
 func (unit *workUnit) countAttempts(tx *sql.Tx) (int, error) {
 	params := queryParams{}
 	query := buildSelect(

--- a/postgres/attempt.go
+++ b/postgres/attempt.go
@@ -370,6 +370,16 @@ func (unit *workUnit) ClearActiveAttempt() error {
 	return execInTx(unit, query, params, true)
 }
 
+func (unit *workUnit) NumAttempts() (int, error) {
+	num := 0
+	var err error
+	withTx(unit, true, func(tx *sql.Tx) error {
+		num, err = unit.countAttempts(tx)
+		return err
+	})
+	return num, err
+}
+
 func (unit *workUnit) Attempts() ([]coordinate.Attempt, error) {
 	params := queryParams{}
 	query := buildSelect([]string{

--- a/restclient/work_unit.go
+++ b/restclient/work_unit.go
@@ -129,3 +129,12 @@ func (unit *workUnit) Attempts() ([]coordinate.Attempt, error) {
 	}
 	return attempts, nil
 }
+
+func (unit *workUnit) NumAttempts() (int, error) {
+	var repr restdata.AttemptList
+	err := unit.GetFrom(unit.Representation.AttemptsURL, map[string]interface{}{}, &repr)
+	if err != nil {
+		return 0, err
+	}
+	return len(repr.Attempts), nil
+}

--- a/restserver/work_unit.go
+++ b/restserver/work_unit.go
@@ -164,6 +164,14 @@ func (api *restAPI) WorkUnitAttempts(ctx *context) (interface{}, error) {
 	return api.returnAttempts(ctx, attempts)
 }
 
+func (api *restAPI) WorkUnitNumAttempts(ctx *context) (interface{}, error) {
+	attempts, err := ctx.WorkUnit.NumAttempts()
+	if err != nil {
+		return 0, err
+	}
+	return attempts, nil
+}
+
 // PopulateWorkUnit adds routes to a namespace router to manipulate
 // work unit.  r should generally be rooted in a subpath like
 // /namespace/{}/work_spec/{}.
@@ -185,6 +193,11 @@ func (api *restAPI) PopulateWorkUnit(r *mux.Router) {
 		Representation: restdata.AttemptList{},
 		Context:        api.Context,
 		Get:            api.WorkUnitAttempts,
+	})
+	r.Path("/work_unit/{unit}/num-attempts").Name("workUnitNumAttempts").Handler(&resourceHandler{
+		Representation: 0,
+		Context:        api.Context,
+		Get:            api.WorkUnitNumAttempts,
 	})
 	sr := r.PathPrefix("/work_unit/{unit}").Subrouter()
 	api.PopulateAttempt(sr)


### PR DESCRIPTION
NumAttempts() should be heavily preferred to len(Attempts()), as
the latter will issue a network request for every attempt. When
there are items that have hundreds of attempts this can slow things
down significantly.

Initially I had intended to just add a NumAttempts() method to the
client, but it turns out this is the same interface used by
coordinate internally. I added this method to all other implementors,
but note that the REST client is still calling the old /attempts
endpoint and then returning the length (but not initiating all that
extra work).

Ideally we would call the new endpoint but in the interest of changing
as little as possible I opted for the path that doesn't require
redeploying the server.

This is intended to address https://github.com/diffeo/nucleus/issues/1124#issuecomment-419444336