### PR TITLE
Add HTTP request logging middleware

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -24,6 +24,12 @@
   revision = "2bba0603135d7d7f5cb73b2125beeda19c09f4ef"
 
 [[projects]]
+  name = "github.com/google/go-cloud"
+  packages = ["requestlog"]
+  revision = "7a6776b9aa5d9e7400c46516ad5aa4f75091316a"
+  version = "v0.2.0"
+
+[[projects]]
   name = "github.com/gorilla/context"
   packages = ["."]
   revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
@@ -43,7 +49,10 @@
 
 [[projects]]
   name = "github.com/lib/pq"
-  packages = [".","oid"]
+  packages = [
+    ".",
+    "oid"
+  ]
   revision = "472a0745531a17dbac346e828b4c60e73ddff30c"
 
 [[projects]]
@@ -64,7 +73,10 @@
 
 [[projects]]
   name = "github.com/prometheus/client_golang"
-  packages = ["prometheus","prometheus/promhttp"]
+  packages = [
+    "prometheus",
+    "prometheus/promhttp"
+  ]
   revision = "c5b7fccd204277076155f10851dad72b76a49317"
   version = "v0.8.0"
 
@@ -75,17 +87,27 @@
 
 [[projects]]
   name = "github.com/prometheus/common"
-  packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","model"]
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model"
+  ]
   revision = "49fee292b27bfff7f354ee0f64e1bc4850462edf"
 
 [[projects]]
   name = "github.com/prometheus/procfs"
-  packages = [".","xfs"]
+  packages = [
+    ".",
+    "xfs"
+  ]
   revision = "a1dba9ce8baed984a2495b658c82687f8157b98f"
 
 [[projects]]
   name = "github.com/rubenv/sql-migrate"
-  packages = [".","sqlparse"]
+  packages = [
+    ".",
+    "sqlparse"
+  ]
   revision = "a3e2963537993d229b6e257d10bd8bc640b06ce3"
 
 [[projects]]
@@ -102,7 +124,11 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert","require","suite"]
+  packages = [
+    "assert",
+    "require",
+    "suite"
+  ]
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
@@ -115,6 +141,12 @@
   name = "github.com/urfave/cli"
   packages = ["."]
   revision = "ab403a54a148f2d857920810291539e1f817ee7b"
+
+[[projects]]
+  name = "github.com/urfave/negroni"
+  packages = ["."]
+  revision = "c6a59be0ce122566695fbd5e48a77f8f10c8a63a"
+  version = "v1.0.0"
 
 [[projects]]
   name = "golang.org/x/sys"
@@ -135,6 +167,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "09d48db6dbbfd4e37fa0b9adfb850de9292b6ab8979c542a79961c75e02dc64b"
+  inputs-digest = "bd576084bd075616a517feef1ae9c273eee5586bef332ae337777f6044be68fe"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -60,3 +60,11 @@
 
 [[constraint]]
   name = "gopkg.in/yaml.v2"
+
+[[constraint]]
+  name = "github.com/urfave/negroni"
+  version = "1.0.0"
+
+[[constraint]]
+  name = "github.com/google/go-cloud"
+  version = "0.2.0"

--- a/cmd/coordinated/http.go
+++ b/cmd/coordinated/http.go
@@ -5,11 +5,15 @@ package main
 
 import (
 	"net/http"
+	"os"
 
 	"github.com/diffeo/go-coordinate/coordinate"
 	"github.com/diffeo/go-coordinate/restserver"
+	"github.com/google/go-cloud/requestlog"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/negroni"
 )
 
 // HTTP serves HTTP coordinated connections.
@@ -21,10 +25,48 @@ type HTTP struct {
 // Serve runs an HTTP server on the specified local address. This serves
 // connections forever, and probably wants to be run in a goroutine. Panics on
 // any error in the initial setup or in accepting connections.
-func (h *HTTP) Serve() {
+func (h *HTTP) Serve(logRequests bool, logFormat string, logger *logrus.Logger) {
 	r := mux.NewRouter()
 	r.PathPrefix("/").Subrouter()
 	restserver.PopulateRouter(r, h.coord)
 	r.Handle("/metrics", promhttp.Handler())
-	http.ListenAndServe(h.laddr, r)
+
+	n := negroni.New()
+	n.Use(negroni.NewRecovery())
+
+	// Wrap the root handler in a logger if desired.
+	var handler http.Handler = r
+	if logRequests {
+		handler = logWrapper(logFormat, logger, handler)
+	}
+	n.UseHandler(handler)
+
+	http.ListenAndServe(h.laddr, n)
+}
+
+// logWrapper creates a wrapping logger for the given handler. It is setup this
+// way rather than conforming to the negroni paradigm because the API fo the
+// requestlog package, which this uses, is not directly compatible.
+func logWrapper(logFormat string, logger *logrus.Logger, inner http.Handler) http.Handler {
+	var reqLog requestlog.Logger
+	// See the following documentation for more information on formats:
+	// https://godoc.org/github.com/google/go-cloud/requestlog
+	switch logFormat {
+	case "ncsa":
+		// Combined Log Format, as used by Apache.
+		reqLog = requestlog.NewNCSALogger(os.Stderr, func(err error) {
+			logger.WithError(err).Error("error writing NCSA log")
+		})
+
+	case "stackdriver":
+		// As expected by Stackdriver Logging.
+		reqLog = requestlog.NewStackdriverLogger(os.Stderr, func(err error) {
+			logger.WithError(err).Error("error writing Stackdriver log")
+		})
+
+	default:
+		logger.WithField("format", logFormat).Fatal("unrecognized log format")
+	}
+
+	return requestlog.NewHandler(reqLog, inner)
 }

--- a/cmd/coordinated/main.go
+++ b/cmd/coordinated/main.go
@@ -34,6 +34,7 @@ func main() {
 	config := flag.String("config", "", "global configuration YAML file")
 	logRequests := flag.Bool("log-requests", false, "log all requests")
 	logMetrics := flag.Bool("log-metrics", false, "log metrics")
+	logFormat := flag.String("log-format", "ncsa", "request log format [ncsa stackdriver]")
 	metricPeriod := flag.String("metric-period", "2m", "time period between each metric update")
 	flag.Parse()
 
@@ -80,7 +81,7 @@ func main() {
 		coord: coordinate,
 		laddr: *httpBind,
 	}
-	go http.Serve()
+	go http.Serve(*logRequests, *logFormat, reqLogger)
 	go Observe(context.Background(), coordinate, period, metricsLogger)
 
 	select {}


### PR DESCRIPTION
This commit updates the HTTP endpoints with the same level of introspectability that the CBOR RPC server functionality provides. I've introduced two new packages as part of this, negroni, and the [new](https://blog.golang.org/go-cloud) go-cloud/requestlog package. Negroni didn't end up being used for the logger, as it is incompatible with the way the logger is intended to be used, but the recovery middleware seemed like a good idea to have anyhow.