### PR TITLE
cmd/coordinated: send http request logs to stdout instead of stderr

### DIFF
--- a/cmd/coordinated/http.go
+++ b/cmd/coordinated/http.go
@@ -54,13 +54,13 @@ func logWrapper(logFormat string, logger *logrus.Logger, inner http.Handler) htt
 	switch logFormat {
 	case "ncsa":
 		// Combined Log Format, as used by Apache.
-		reqLog = requestlog.NewNCSALogger(os.Stderr, func(err error) {
+		reqLog = requestlog.NewNCSALogger(os.Stdout, func(err error) {
 			logger.WithError(err).Error("error writing NCSA log")
 		})
 
 	case "stackdriver":
 		// As expected by Stackdriver Logging.
-		reqLog = requestlog.NewStackdriverLogger(os.Stderr, func(err error) {
+		reqLog = requestlog.NewStackdriverLogger(os.Stdout, func(err error) {
 			logger.WithError(err).Error("error writing Stackdriver log")
 		})
 


### PR DESCRIPTION
This allows them to better mesh with various external systems
that provide log visualization, such as Google Cloud Stackdriver,
which interprets stdout/stderr as levels in the UI. HTTP request
logs should not be considered "errors".

This is a fix building on top of the work in:
https://github.com/diffeo/go-coordinate/pull/22