### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/memory/available_units.go
+++ b/memory/available_units.go
@@ -15,7 +15,7 @@ func (q *availableUnits) Add(unit *workUnit) {
 	heap.Push(q, unit)
 }
 
-// Get the next available unit, with the highest priority and lowest name.
+// Next gets the next available unit, with the highest priority and lowest name.
 func (q *availableUnits) Next() *workUnit {
 	return heap.Pop(q).(*workUnit)
 }

--- a/postgres/sql.go
+++ b/postgres/sql.go
@@ -308,12 +308,12 @@ type fieldList struct {
 	Fields []fieldPair
 }
 
-// Adds a name and dynamic value to the field list.
+// Add adds a name and dynamic value to the field list.
 func (f *fieldList) Add(qp *queryParams, field string, value interface{}) {
 	f.AddDirect(field, qp.Param(value))
 }
 
-// Adds a name and fixed value to the field list.  value is an unquoted
+// AddDirect adds a name and fixed value to the field list.  value is an unquoted
 // SQL string.
 func (f *fieldList) AddDirect(field, value string) {
 	f.Fields = append(f.Fields, fieldPair{Field: field, Value: value})


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?